### PR TITLE
Separate self password change and admin reset endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ curl -b cookie.txt http://localhost:8080/auth/me
 ```
 
 ### Create user
+`roleCode` must be provided (e.g., `user` or `admin`). Newly created users start with `active` status.
 ```bash
 curl -b cookie.txt -X POST http://localhost:8080/users \
   -H "Content-Type: application/json" \
-  -d '{"username":"alice","password":"alice@123","statusCode":"active"}'
+  -d '{"username":"alice","password":"alice@123","roleCode":"user"}'
 ```
 
 ### List users
@@ -37,11 +38,20 @@ curl -b cookie.txt -X POST http://localhost:8080/users \
 curl -b cookie.txt "http://localhost:8080/users?page=0&size=10"
 ```
 
-### Update user
+### Change own password
+Requires the user's current password.
 ```bash
-curl -b cookie.txt -X PATCH http://localhost:8080/users/2 \
+curl -b cookie.txt -X POST http://localhost:8080/me/password \
   -H "Content-Type: application/json" \
-  -d '{"password":"newStrongPass"}'
+  -d '{"oldPassword":"alice@123","newPassword":"newStrongPass"}'
+```
+
+### Admin reset another user's password
+Admins can set a new password for any user without the old password.
+```bash
+curl -b cookie.txt -X POST http://localhost:8080/users/2/password \
+  -H "Content-Type: application/json" \
+  -d '{"newPassword":"newStrongPass"}'
 ```
 
 ### Soft delete

--- a/src/main/java/com/example/ums/controller/MeController.java
+++ b/src/main/java/com/example/ums/controller/MeController.java
@@ -1,0 +1,25 @@
+package com.example.ums.controller;
+
+import com.example.ums.dto.PasswordChangeRequest;
+import com.example.ums.dto.UserResponse;
+import com.example.ums.security.AuthUser;
+import com.example.ums.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/me")
+public class MeController {
+    private final UserService userService;
+
+    public MeController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/password")
+    public UserResponse changePassword(@Valid @RequestBody PasswordChangeRequest req, Authentication auth) {
+        AuthUser user = (AuthUser) auth.getPrincipal();
+        return userService.changePassword(req, user.id());
+    }
+}

--- a/src/main/java/com/example/ums/controller/UsersController.java
+++ b/src/main/java/com/example/ums/controller/UsersController.java
@@ -34,18 +34,18 @@ public class UsersController {
         return userService.create(req, user.id());
     }
 
-    @PutMapping("/{id}")
-    @PatchMapping("/{id}")
-    public UserResponse update(@PathVariable Long id, @RequestBody UserUpdateRequest req, Authentication auth) {
-        AuthUser user = (AuthUser) auth.getPrincipal();
-        return userService.update(id, req, user.id());
-    }
-
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id, Authentication auth) {
         AuthUser user = (AuthUser) auth.getPrincipal();
         userService.delete(id, user.id());
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/password")
+    public UserResponse resetPassword(@PathVariable Long id, @Valid @RequestBody PasswordResetRequest req,
+                                      Authentication auth) {
+        AuthUser user = (AuthUser) auth.getPrincipal();
+        return userService.resetPassword(id, req, user.id());
     }
 
     @PostMapping("/{id}/reset-failed-attempts")

--- a/src/main/java/com/example/ums/dto/PasswordChangeRequest.java
+++ b/src/main/java/com/example/ums/dto/PasswordChangeRequest.java
@@ -1,0 +1,6 @@
+package com.example.ums.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordChangeRequest(@NotBlank String oldPassword,
+                                    @NotBlank String newPassword) {}

--- a/src/main/java/com/example/ums/dto/PasswordResetRequest.java
+++ b/src/main/java/com/example/ums/dto/PasswordResetRequest.java
@@ -1,0 +1,5 @@
+package com.example.ums.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordResetRequest(@NotBlank String newPassword) {}

--- a/src/main/java/com/example/ums/dto/UserCreateRequest.java
+++ b/src/main/java/com/example/ums/dto/UserCreateRequest.java
@@ -2,5 +2,7 @@ package com.example.ums.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record UserCreateRequest(@NotBlank String username, @NotBlank String password,
-                                String statusCode, String roleCode) {}
+public record UserCreateRequest(
+        @NotBlank String username,
+        @NotBlank String password,
+        @NotBlank String roleCode) {}

--- a/src/main/java/com/example/ums/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/ums/dto/UserUpdateRequest.java
@@ -1,3 +1,0 @@
-package com.example.ums.dto;
-
-public record UserUpdateRequest(String username, String password, String statusCode, String roleCode) {}

--- a/src/test/java/com/example/ums/service/UserServiceTest.java
+++ b/src/test/java/com/example/ums/service/UserServiceTest.java
@@ -1,0 +1,93 @@
+package com.example.ums.service;
+
+import com.example.ums.dto.PasswordChangeRequest;
+import com.example.ums.dto.PasswordResetRequest;
+import com.example.ums.entity.StatusCodeEntity;
+import com.example.ums.entity.UserEntity;
+import com.example.ums.entity.UserRoleEntity;
+import com.example.ums.repo.StatusCodeRepository;
+import com.example.ums.repo.UserRepository;
+import com.example.ums.repo.UserRoleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StatusCodeRepository statusCodeRepository;
+
+    @Autowired
+    private UserRoleRepository userRoleRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    private UserEntity admin;
+    private UserEntity user;
+
+    @BeforeEach
+    void setup() {
+        userRepository.deleteAll();
+        statusCodeRepository.deleteAll();
+        userRoleRepository.deleteAll();
+
+        StatusCodeEntity active = new StatusCodeEntity();
+        active.setDomain("ums");
+        active.setCode("active");
+        active.setName("Active");
+        active.setIsActive(true);
+        active = statusCodeRepository.save(active);
+
+        UserRoleEntity adminRole = new UserRoleEntity();
+        adminRole.setCode("admin");
+        adminRole.setName("Admin");
+        adminRole.setIsActive(true);
+        adminRole = userRoleRepository.save(adminRole);
+
+        UserRoleEntity userRole = new UserRoleEntity();
+        userRole.setCode("user");
+        userRole.setName("User");
+        userRole.setIsActive(true);
+        userRole = userRoleRepository.save(userRole);
+
+        admin = new UserEntity();
+        admin.setUsername("admin");
+        admin.setPasswordHash(passwordEncoder.encode("adminpass"));
+        admin.setStatusId(active.getId());
+        admin.setRoleId(adminRole.getId());
+        admin = userRepository.save(admin);
+
+        user = new UserEntity();
+        user.setUsername("john");
+        user.setPasswordHash(passwordEncoder.encode("oldpass"));
+        user.setStatusId(active.getId());
+        user.setRoleId(userRole.getId());
+        user = userRepository.save(user);
+    }
+
+    @Test
+    void userCanChangeOwnPassword() {
+        userService.changePassword(new PasswordChangeRequest("oldpass", "newpass"), user.getId());
+        UserEntity updated = userRepository.findById(user.getId()).orElseThrow();
+        assertTrue(passwordEncoder.matches("newpass", updated.getPasswordHash()));
+    }
+
+    @Test
+    void adminCanResetOtherPassword() {
+        userService.resetPassword(user.getId(), new PasswordResetRequest("resetpass"), admin.getId());
+        UserEntity updated = userRepository.findById(user.getId()).orElseThrow();
+        assertTrue(passwordEncoder.matches("resetpass", updated.getPasswordHash()));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `POST /me/password` so users can update their own password after providing the current password
- Provide admin-only `POST /users/{id}/password` to reset another user's password without the old password
- Document new password endpoints and cover them with tests

## Testing
- `./mvnw -q test` *(fails: Permission denied)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a6c831a1648332829ec5d16f1ce0c7