### PR TITLE
feat: allow configuring db connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The application reads database connection details from the following environment
 | ------------- | ---------- | ---------------------------- |
 | `DB_HOST`     | `localhost`| PostgreSQL host name         |
 | `DB_PORT`     | `5432`     | PostgreSQL port              |
+| `DB_NAME`     | `wms`      | Database name                |
+| `DB_SCHEMA`   | `ums`      | Default schema               |
 | `DB_USERNAME` | `wms`      | Database user                |
 | `DB_PASSWORD` | `wms`      | Database password            |
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: wms
   datasource:
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/wms?currentSchema=ums
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:wms}?currentSchema=${DB_SCHEMA:ums}
     username: ${DB_USERNAME:wms}
     password: ${DB_PASSWORD:wms}
     driver-class-name: org.postgresql.Driver
@@ -12,7 +12,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
-        default_schema: ums
+        default_schema: ${DB_SCHEMA:ums}
   sql:
     init:
       mode: never


### PR DESCRIPTION
## Summary
- make database host, port and credentials configurable via environment variables
- document database connection environment variables in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_68a90750b7e483328b193d5ddad9b0b0