### PR TITLE
Rename error code field to messageCode

### DIFF
--- a/src/main/java/com/vietnguyen/ums/exception/ApiException.java
+++ b/src/main/java/com/vietnguyen/ums/exception/ApiException.java
@@ -8,19 +8,19 @@ import org.springframework.http.HttpStatus;
  */
 public class ApiException extends RuntimeException {
     private final HttpStatus status;
-    private final String code;
+    private final String messageCode;
 
-    public ApiException(HttpStatus status, String code, String message) {
+    public ApiException(HttpStatus status, String messageCode, String message) {
         super(message);
         this.status = status;
-        this.code = code;
+        this.messageCode = messageCode;
     }
 
     public HttpStatus getStatus() {
         return status;
     }
 
-    public String getCode() {
-        return code;
+    public String getMessageCode() {
+        return messageCode;
     }
 }

--- a/src/main/java/com/vietnguyen/ums/exception/ErrorResponse.java
+++ b/src/main/java/com/vietnguyen/ums/exception/ErrorResponse.java
@@ -2,4 +2,4 @@ package com.vietnguyen.ums.exception;
 
 import java.time.Instant;
 
-public record ErrorResponse(String code, String message, String path, Instant timestamp) {}
+public record ErrorResponse(String messageCode, String message, String path, Instant timestamp) {}

--- a/src/main/java/com/vietnguyen/ums/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/vietnguyen/ums/exception/GlobalExceptionHandler.java
@@ -13,7 +13,7 @@ import java.time.Instant;
 public class GlobalExceptionHandler {
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<ErrorResponse> handle(ApiException ex, HttpServletRequest req) {
-        ErrorResponse body = new ErrorResponse(ex.getCode(), ex.getMessage(), req.getRequestURI(), Instant.now());
+        ErrorResponse body = new ErrorResponse(ex.getMessageCode(), ex.getMessage(), req.getRequestURI(), Instant.now());
         return ResponseEntity.status(ex.getStatus()).body(body);
     }
 
@@ -23,10 +23,10 @@ public class GlobalExceptionHandler {
         String msg = fieldError
                 .map(f -> f.getField() + ": " + f.getDefaultMessage())
                 .orElse("Validation error");
-        String code = fieldError
+        String messageCode = fieldError
                 .map(f -> toCode(f.getField() + " " + f.getDefaultMessage()))
                 .orElse("VALIDATION_ERROR");
-        ErrorResponse body = new ErrorResponse(code, msg, req.getRequestURI(), Instant.now());
+        ErrorResponse body = new ErrorResponse(messageCode, msg, req.getRequestURI(), Instant.now());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
 


### PR DESCRIPTION
## Summary
- Rename ApiException field to messageCode
- Return messageCode in error responses
- Use messageCode in validation error handling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68aa56fe62a48332be3769b07f9cf1b6